### PR TITLE
Supporting more data types for UDAFMapGroupSum

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 lib
 dist
 build
+ivy

--- a/README.md
+++ b/README.md
@@ -232,7 +232,18 @@ A Table will be created with one line per tag, with the raw XML content of each 
 
 Note that the storage handler does not perform any XML entity substitution (such as &gt; or unicode entities)
 
-qaa
+## Contributing
+
+#### Set up a docker container with ivy
+`docker run -it -v /path/to/dataiku-hive-udf/:/dataiku fogartyp/ant-ivy /bin/bash`
+
+#### Building the jar
+`cd /dataiku/`
+
+`ant`
+
+The jar will be placed in the `dist` folder.
+
 ## Copyright and license
 
 Copyright 2013 Dataiku SAS.

--- a/build.xml
+++ b/build.xml
@@ -14,7 +14,7 @@
     <target name="download-ivy" unless="skip.download">
         <mkdir dir="${ivy.jar.dir}"/>
         <echo message="installing ivy..."/>
-        <get src="http://repo1.maven.org/maven2/org/apache/ivy/ivy/${ivy.install.version}/ivy-${ivy.install.version}.jar" dest="${ivy.jar.file}" usetimestamp="true"/>
+        <get src="https://repo1.maven.org/maven2/org/apache/ivy/ivy/${ivy.install.version}/ivy-${ivy.install.version}.jar" dest="${ivy.jar.file}" usetimestamp="true"/>
     </target>
     <target name="install-ivy" depends="download-ivy" description="--> install ivy">
         <path id="ivy.lib.path">
@@ -37,7 +37,7 @@
     </target>
 
     <target name="jar" depends="compile">
-      <copy file="hive-init.hql" todir="${dist.dir}" /> 
+      <copy file="hive-init.hql" todir="${dist.dir}" />
       <delete file="${dist.dir}/dataiku-hive-udf.jar" />
       <jar destfile="${dist.dir}/dataiku-hive-udf.jar" basedir="${build.dir}/classes" />
     </target>

--- a/ivy.xml
+++ b/ivy.xml
@@ -29,12 +29,13 @@
    <exclude org="commons-daemon" />
         </dependency>
         <dependency org="javax.jdo" name="jdo2-api" rev="2.3-eb" force="true"/>
-        <dependency org="org.jboss.netty" name="netty" rev="3.2.9" force="true" />
-<!--<dependency org="commons-daemon" name="commons-daemon" rev="1.0.15" force="true"/>-->            
+        <dependency org="org.jboss.netty" name="netty" rev="3.2.9.Final" force="true" />
+<!--<dependency org="commons-daemon" name="commons-daemon" rev="1.0.15" force="true"/>-->
 
         <!--<dependency org="commons-lang" name="commons-lang" rev="2.5"/>
         <dependency org="commons-io" name="commons-io" rev="2.1"/>
         <dependency org="commons-collections" name="commons-collections" rev="3.2.1"/>-->
+        <dependency org="com.google.collections" name="google-collections" rev="1.0-rc2"/>
  	<!--<dependency org="commons-codec" name="commons-codec" rev="1.7" />-->
         <dependency org="com.google.code.gson" name="gson" rev="2.2.2"/>
         <dependency org="com.google.guava" name="guava" rev="16.0.1" />

--- a/src/com/dataiku/hive/udf/maps/UDAFMapGroupSum.java
+++ b/src/com/dataiku/hive/udf/maps/UDAFMapGroupSum.java
@@ -11,6 +11,9 @@ import org.apache.hadoop.hive.serde2.lazy.LazyMap;
 import org.apache.hadoop.hive.serde2.lazy.objectinspector.LazyMapObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.*;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.IntObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.LongObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.FloatObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.DoubleObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.StringObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
@@ -29,7 +32,18 @@ public class UDAFMapGroupSum extends AbstractGenericUDAFResolver {
         if (tis.length != 1) {
             throw new UDFArgumentTypeException(tis.length - 1, "Exactly one argument is expected.");
         }
-        return new MapGroupSumEvaluator();
+        if (tis[0].getTypeName().equals("map<string,int>")) {
+            return new MapGroupSumEvaluator();
+        } else if (tis[0].getTypeName().equals("map<string,bigint>")) {
+            return new MapGroupSumLongEvaluator();
+        } else if (tis[0].getTypeName().equals("map<string,double>")) {
+            return new MapGroupSumDoubleEvaluator();
+        } else if (tis[0].getTypeName().equals("map<string,float>")) {
+            return new MapGroupSumFloatEvaluator();
+        } else {
+            throw new UDFArgumentTypeException(0,
+                "Only supports map<string,int>, map<string,bigint>, map<string,float>, and map<string, double>.  Got: '" + tis[0].getTypeName() + "'");
+        }
     }
 
     public static class MapGroupSumEvaluator extends GenericUDAFEvaluator {
@@ -89,6 +103,300 @@ public class UDAFMapGroupSum extends AbstractGenericUDAFResolver {
                 if (okey == null || ovalue == null) continue;
                 String key = keyOI.getPrimitiveJavaObject(entry.getKey());
                 Integer value = valueOI.get(entry.getValue());
+                if (m.containsKey(key)) {
+                    m.put(key, m.get(key) + value);
+                } else {
+                    m.put(key, value);
+                }
+            }
+        }
+
+        @Override
+        public void iterate(AggregationBuffer ab, Object[] parameters)  throws HiveException {
+            assert (parameters.length == 1);
+            Object p = parameters[0];
+            if (p != null) {
+                MapBuffer agg = (MapBuffer) ab;
+                Map<Object, Object> o = (Map<Object, Object>) this.originalDataOI.getMap(p);
+                mapAppend(agg.map, o);
+            }
+        }
+
+        @Override
+        public Object terminatePartial(AggregationBuffer ab) throws HiveException {
+            MapBuffer agg = (MapBuffer) ab;
+            return Maps.newHashMap(agg.map);
+        }
+
+        @Override
+        public void merge(AggregationBuffer ab, Object p) throws HiveException {
+            MapBuffer agg = (MapBuffer) ab;
+            @SuppressWarnings("unchecked")
+            Map<Object, Object> obj = (Map<Object, Object>) this.originalDataOI.getMap(p);
+            mapAppend(agg.map, obj);
+        }
+
+        @Override
+        public Object terminate(AggregationBuffer ab)  throws HiveException {
+            MapBuffer agg = (MapBuffer) ab;
+            return Maps.newHashMap(agg.map);
+        }
+    }
+    
+    
+    public static class MapGroupSumLongEvaluator extends GenericUDAFEvaluator {
+        private MapObjectInspector originalDataOI;
+        private LongObjectInspector valueOI;
+        private StringObjectInspector keyOI;
+
+
+        @Override
+        public ObjectInspector init(Mode m, ObjectInspector[] parameters) throws HiveException {
+            super.init(m, parameters);
+
+            originalDataOI = (MapObjectInspector) parameters[0];
+            keyOI = (StringObjectInspector) originalDataOI.getMapKeyObjectInspector();
+            valueOI = (LongObjectInspector) originalDataOI.getMapValueObjectInspector();
+            return ObjectInspectorFactory.getStandardMapObjectInspector(PrimitiveObjectInspectorFactory.javaStringObjectInspector,
+                        PrimitiveObjectInspectorFactory.javaLongObjectInspector);
+
+
+
+//            /* Setup input OI */
+//            if (m == Mode.PARTIAL1 || m == Mode.COMPLETE) {
+//                /* Input is original data */
+//                originalDataOI = parameters[0];
+//            } else if (m == Mode.PARTIAL2 || m == Mode.FINAL){
+//                /* Input is list of original data */
+//                listOI = (StandardListObjectInspector) parameters[0];
+//                originalDataOI = listOI.getListElementObjectInspector();
+//            }
+//
+//            /* Output OI : always a list of original data */
+//            return ObjectInspectorFactory
+//                    .getStandardListObjectInspector(ObjectInspectorUtils.getStandardObjectInspector(originalDataOI));
+        }
+
+        static class MapBuffer implements AggregationBuffer {
+            Map<String, Long> map = new HashMap<String, Long>();
+        }
+
+        @Override
+        public void reset(AggregationBuffer ab) throws HiveException {
+            ((MapBuffer) ab).map.clear();
+        }
+
+        @Override
+        public AggregationBuffer getNewAggregationBuffer() throws HiveException {
+            return new MapBuffer();
+        }
+
+        protected void mapAppend(Map<String, Long> m, Map<Object, Object> from)  {
+            if (from == null) {
+                return;
+            }
+            for(Map.Entry<Object, Object> entry : from.entrySet()) {
+                Object okey = entry.getKey();
+                Object ovalue = entry.getValue();
+                if (okey == null || ovalue == null) continue;
+                String key = keyOI.getPrimitiveJavaObject(entry.getKey());
+                Long value = valueOI.get(entry.getValue());
+                if (m.containsKey(key)) {
+                    m.put(key, m.get(key) + value);
+                } else {
+                    m.put(key, value);
+                }
+            }
+        }
+
+        @Override
+        public void iterate(AggregationBuffer ab, Object[] parameters)  throws HiveException {
+            assert (parameters.length == 1);
+            Object p = parameters[0];
+            if (p != null) {
+                MapBuffer agg = (MapBuffer) ab;
+                Map<Object, Object> o = (Map<Object, Object>) this.originalDataOI.getMap(p);
+                mapAppend(agg.map, o);
+            }
+        }
+
+        @Override
+        public Object terminatePartial(AggregationBuffer ab) throws HiveException {
+            MapBuffer agg = (MapBuffer) ab;
+            return Maps.newHashMap(agg.map);
+        }
+
+        @Override
+        public void merge(AggregationBuffer ab, Object p) throws HiveException {
+            MapBuffer agg = (MapBuffer) ab;
+            @SuppressWarnings("unchecked")
+            Map<Object, Object> obj = (Map<Object, Object>) this.originalDataOI.getMap(p);
+            mapAppend(agg.map, obj);
+        }
+
+        @Override
+        public Object terminate(AggregationBuffer ab)  throws HiveException {
+            MapBuffer agg = (MapBuffer) ab;
+            return Maps.newHashMap(agg.map);
+        }
+    }
+
+
+    public static class MapGroupSumDoubleEvaluator extends GenericUDAFEvaluator {
+        private MapObjectInspector originalDataOI;
+        private DoubleObjectInspector valueOI;
+        private StringObjectInspector keyOI;
+
+
+        @Override
+        public ObjectInspector init(Mode m, ObjectInspector[] parameters) throws HiveException {
+            super.init(m, parameters);
+
+            originalDataOI = (MapObjectInspector) parameters[0];
+            keyOI = (StringObjectInspector) originalDataOI.getMapKeyObjectInspector();
+            valueOI = (DoubleObjectInspector) originalDataOI.getMapValueObjectInspector();
+            return ObjectInspectorFactory.getStandardMapObjectInspector(PrimitiveObjectInspectorFactory.javaStringObjectInspector,
+                        PrimitiveObjectInspectorFactory.javaDoubleObjectInspector);
+
+
+
+//            /* Setup input OI */
+//            if (m == Mode.PARTIAL1 || m == Mode.COMPLETE) {
+//                /* Input is original data */
+//                originalDataOI = parameters[0];
+//            } else if (m == Mode.PARTIAL2 || m == Mode.FINAL){
+//                /* Input is list of original data */
+//                listOI = (StandardListObjectInspector) parameters[0];
+//                originalDataOI = listOI.getListElementObjectInspector();
+//            }
+//
+//            /* Output OI : always a list of original data */
+//            return ObjectInspectorFactory
+//                    .getStandardListObjectInspector(ObjectInspectorUtils.getStandardObjectInspector(originalDataOI));
+        }
+
+        static class MapBuffer implements AggregationBuffer {
+            Map<String, Double> map = new HashMap<String, Double>();
+        }
+
+        @Override
+        public void reset(AggregationBuffer ab) throws HiveException {
+            ((MapBuffer) ab).map.clear();
+        }
+
+        @Override
+        public AggregationBuffer getNewAggregationBuffer() throws HiveException {
+            return new MapBuffer();
+        }
+
+        protected void mapAppend(Map<String, Double> m, Map<Object, Object> from)  {
+            if (from == null) {
+                return;
+            }
+            for(Map.Entry<Object, Object> entry : from.entrySet()) {
+                Object okey = entry.getKey();
+                Object ovalue = entry.getValue();
+                if (okey == null || ovalue == null) continue;
+                String key = keyOI.getPrimitiveJavaObject(entry.getKey());
+                Double value = valueOI.get(entry.getValue());
+                if (m.containsKey(key)) {
+                    m.put(key, m.get(key) + value);
+                } else {
+                    m.put(key, value);
+                }
+            }
+        }
+
+        @Override
+        public void iterate(AggregationBuffer ab, Object[] parameters)  throws HiveException {
+            assert (parameters.length == 1);
+            Object p = parameters[0];
+            if (p != null) {
+                MapBuffer agg = (MapBuffer) ab;
+                Map<Object, Object> o = (Map<Object, Object>) this.originalDataOI.getMap(p);
+                mapAppend(agg.map, o);
+            }
+        }
+
+        @Override
+        public Object terminatePartial(AggregationBuffer ab) throws HiveException {
+            MapBuffer agg = (MapBuffer) ab;
+            return Maps.newHashMap(agg.map);
+        }
+
+        @Override
+        public void merge(AggregationBuffer ab, Object p) throws HiveException {
+            MapBuffer agg = (MapBuffer) ab;
+            @SuppressWarnings("unchecked")
+            Map<Object, Object> obj = (Map<Object, Object>) this.originalDataOI.getMap(p);
+            mapAppend(agg.map, obj);
+        }
+
+        @Override
+        public Object terminate(AggregationBuffer ab)  throws HiveException {
+            MapBuffer agg = (MapBuffer) ab;
+            return Maps.newHashMap(agg.map);
+        }
+    }
+
+
+    public static class MapGroupSumFloatEvaluator extends GenericUDAFEvaluator {
+        private MapObjectInspector originalDataOI;
+        private FloatObjectInspector valueOI;
+        private StringObjectInspector keyOI;
+
+
+        @Override
+        public ObjectInspector init(Mode m, ObjectInspector[] parameters) throws HiveException {
+            super.init(m, parameters);
+
+            originalDataOI = (MapObjectInspector) parameters[0];
+            keyOI = (StringObjectInspector) originalDataOI.getMapKeyObjectInspector();
+            valueOI = (FloatObjectInspector) originalDataOI.getMapValueObjectInspector();
+            return ObjectInspectorFactory.getStandardMapObjectInspector(PrimitiveObjectInspectorFactory.javaStringObjectInspector,
+                        PrimitiveObjectInspectorFactory.javaFloatObjectInspector);
+
+
+
+//            /* Setup input OI */
+//            if (m == Mode.PARTIAL1 || m == Mode.COMPLETE) {
+//                /* Input is original data */
+//                originalDataOI = parameters[0];
+//            } else if (m == Mode.PARTIAL2 || m == Mode.FINAL){
+//                /* Input is list of original data */
+//                listOI = (StandardListObjectInspector) parameters[0];
+//                originalDataOI = listOI.getListElementObjectInspector();
+//            }
+//
+//            /* Output OI : always a list of original data */
+//            return ObjectInspectorFactory
+//                    .getStandardListObjectInspector(ObjectInspectorUtils.getStandardObjectInspector(originalDataOI));
+        }
+
+        static class MapBuffer implements AggregationBuffer {
+            Map<String, Float> map = new HashMap<String, Float>();
+        }
+
+        @Override
+        public void reset(AggregationBuffer ab) throws HiveException {
+            ((MapBuffer) ab).map.clear();
+        }
+
+        @Override
+        public AggregationBuffer getNewAggregationBuffer() throws HiveException {
+            return new MapBuffer();
+        }
+
+        protected void mapAppend(Map<String, Float> m, Map<Object, Object> from)  {
+            if (from == null) {
+                return;
+            }
+            for(Map.Entry<Object, Object> entry : from.entrySet()) {
+                Object okey = entry.getKey();
+                Object ovalue = entry.getValue();
+                if (okey == null || ovalue == null) continue;
+                String key = keyOI.getPrimitiveJavaObject(entry.getKey());
+                Float value = valueOI.get(entry.getValue());
                 if (m.containsKey(key)) {
                     m.put(key, m.get(key) + value);
                 } else {


### PR DESCRIPTION
- Ensuring data types like bigint, double, float can all be used with UDAFMapGroupSum
- Making build work
- Documentation around how to build